### PR TITLE
Allow entry of multiple Alias tags

### DIFF
--- a/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
@@ -312,7 +312,9 @@ PersistentBufferFile={{ zabbix_agent2_persistentbufferfile }}
 # Range:
 # Default:
 {% if zabbix_agent2_zabbix_alias is defined and zabbix_agent2_zabbix_alias %}
-Alias={{ zabbix_agent2_zabbix_alias }}
+{% for alias in zabbix_agent2_zabbix_alias %}
+Alias={{ alias }}
+{% endfor %}
 {% endif %}
 
 ### Option: Timeout

--- a/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
@@ -217,7 +217,9 @@ MaxLinesPerSecond={{ zabbix_agent_maxlinespersecond }}
 #       sets an alias for parameter. it can be useful to substitute long and complex parameter name with a smaller and simpler one.
 #
 {% if zabbix_agent_zabbix_alias is defined and zabbix_agent_zabbix_alias %}
-Alias={{ zabbix_agent_zabbix_alias }}
+{% for alias in zabbix_agent_zabbix_alias %}
+Alias={{ alias }}
+{% endfor %}
 {% endif %}
 
 ### option: timeout


### PR DESCRIPTION
Zabbix agents support having multiple alias tags, however, ansible doesn't allow you to define `zabbix_agent_zabbix_alias` multiple times. Setting this to be an array in YAML will result in it being added the zabbix_agentd.conf as is, e.g., 
```
Alias=["alias1:alias","alias2:alias","alias3:alias"]
```
which isn't acceptable syntax for zabbix_agentd.conf.

This fix to the template allows you set `zabbix_agent_zabbix_alias` as an array of items which will each be given their own line, e.g.,
```
Alias=alias1:alias
Alias=alias2:alias
Alias=alias3:alias
```